### PR TITLE
Update README.md for Remote Network Device access

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Flags:
   -h, --help              help for fuzz
   -i, --input string      path to input directory
   -m, --method string     method of opening url (delegate, app) (default "delegate")
+  -n, --network string    Connect to remote network device (default is "USB")
   -r, --runs uint         number of runs
   -s, --scene string      scene class name
   -t, --timeout uint      sleep X seconds between each case (default 1)
   -u, --uiapp string      UIApplication name
-  -n, --network string    Connect to remote network device (default is "USB")
 ```
 
 There are basically two ways you can go with fuzzing using `furlzz`:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Flags:
   -s, --scene string      scene class name
   -t, --timeout uint      sleep X seconds between each case (default 1)
   -u, --uiapp string      UIApplication name
-  -n, --network string    Connect to remote device (default is "USB")
+  -n, --network string    Connect to remote network device (default is "USB")
 ```
 
 There are basically two ways you can go with fuzzing using `furlzz`:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Flags:
   -s, --scene string      scene class name
   -t, --timeout uint      sleep X seconds between each case (default 1)
   -u, --uiapp string      UIApplication name
+  -n, --network string    Connect to remote device (default is "USB")
 ```
 
 There are basically two ways you can go with fuzzing using `furlzz`:


### PR DESCRIPTION
Adding remote device support. (When device not connected over USB)

Network address like localhost or 127.0.0.1 or other can be provided. 

Local port forwarding from host machine can be configured which would redirect the local port 27042 to mobile/remote device port 27042 using 

ssh -L 27042:127.0.0.1:27042 root@<iDevice_ip>

and then on host machine supply -n "127.0.0.1" with furlzz. 

Also, you can run Frida CLI command "frida-ps -Rai" to test if that port forwarding is working.