### PR TITLE
Adding spawn support

### DIFF
--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -255,7 +255,6 @@ func sendErr(p *tea.Program, msg string) {
 }
 
 func spawnApp(dev *frida.Device, app string, p *tea.Program, toSpawn bool) {
-
 	process, err := dev.FindProcessByName(app, frida.ScopeMinimal)
 	if err != nil {
 		sendErr(p, err.Error())

--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -265,15 +265,13 @@ func spawnApp(dev *frida.Device, app string, p *tea.Program, toSpawn bool) {
 		toSpawn = true
 	} else if process.PID() > 0 {
 		//If app is in process but not in foreground, Spawn it
-		// sometimes crash makes app go in the background
 		frontApp, err := dev.FrontmostApplication(frida.ScopeMinimal)
 		if err != nil {
-			sendErr(p, err.Error())
-			//We don't need to exit/return here, since frida throws generic error if no app is in foreground
+			sendStats(p, err.Error())
+			//We don't need to exit/return here, since frida throws generic error if no app is in foreground.
 		}
+		//if foreground app does not match intended app, spawn it
 		if frontApp == nil || frontApp.Name() != process.Name() {
-			//need to kill app in foreground, else fuzzing seems to stop for some reason
-			dev.Kill(process.PID())
 			toSpawn = true
 		}
 	}


### PR DESCRIPTION
Adding support for app spawn. App will spawn only if not already in foreground. 
i.e Not opened or app is in background.

1) This will help to wake up device (unlocked) and start fuzzing. Instead of manually opening the app.
2) For continuous fuzzing, in case it crashes app and we want to keep it going, this will respawn app and keep looking for more crashes. (Will require more changes for continuous fuzzing, i plan on adding later)