### PR TITLE
Spawn apps if not running or not in foreground

### DIFF
--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -305,8 +305,10 @@ func spawnApp(dev frida.DeviceInt, app string, p *tea.Program, toSpawn bool) {
 			}
 		}
 	sendStats(p, "Spawning app:"+app)
-	//Sleeping for a second before fuzzing so app spawn properly
-	time.Sleep(1 * time.Second)
+	//Sleep for supplied time before fuzzing so app spawn properly
+	if timeout > 0 {
+			time.Sleep(time.Duration(timeout) * time.Second)
+		}
 	}
 }
 

--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -136,6 +136,8 @@ var fuzzCmd = &cobra.Command{
 				}
 				defer dev.Clean()
 
+				//Spawn app only if not in foreground
+				spawnApp(dev, app, p, false)
 				sess, err = dev.Attach(app, nil)
 				if err != nil {
 					sendErr(p, err.Error())
@@ -150,6 +152,8 @@ var fuzzCmd = &cobra.Command{
 				}
 				defer dev.Clean()
 
+				//Spawn app only if not in foreground
+				spawnApp(dev, app, p, false)
 				sess, err = dev.Attach(app, nil)
 				if err != nil {
 					sendErr(p, err.Error())
@@ -249,6 +253,61 @@ func sendStats(p *tea.Program, msg string) {
 
 func sendErr(p *tea.Program, msg string) {
 	p.Send(tui.ErrMsg(msg))
+}
+
+func spawnApp(dev frida.DeviceInt, app string, p *tea.Program, toSpawn bool) {
+	process, err := dev.FindProcessByName(app, frida.ScopeMinimal)
+	if err != nil {
+		sendErr(p, err.Error())
+		return
+	}
+	//If app is not open, Spawn it
+	if process.PID() < 0 {
+		toSpawn = true
+	} else if process.PID() > 0 {
+		//If app is in process but not in foreground, Spawn it
+		frontApp, err := dev.FrontmostApplication(frida.ScopeMinimal)
+		if err != nil {
+			//We don't need to exit/return here, since frida throws generic error if no app is in foreground sending as stats
+			sendStats(p, err.Error())
+		}
+		//Checking if foreground app does not match intended app, then we spawn it
+		if frontApp == nil || frontApp.Name() != process.Name() {
+			toSpawn = true
+		}
+	}
+
+	if toSpawn == true {
+		fopts := frida.NewSpawnOptions()
+		fopts.SetArgv([]string{
+			"",
+		})
+		appsList, err := dev.EnumerateApplications("", frida.ScopeMinimal)
+		if err != nil {
+			sendErr(p, err.Error())
+			return
+		}
+
+		for i := 0; i < int(len(appsList)); i++ {
+			appName := appsList[i]
+			if appName.Name() == app {
+				pid, err := dev.Spawn(appName.Identifier(), fopts)
+				if err != nil {
+					sendErr(p, err.Error())
+					return
+				}
+				err = dev.Resume(pid)
+				if err != nil {
+					sendErr(p, err.Error())
+					return
+				}
+				break
+			}
+		}
+	}
+	sendStats(p, "Spawning app:"+app)
+	//Sleeping for a second before fuzzing so app spawn properly
+	time.Sleep(1 * time.Second)
 }
 
 func init() {

--- a/cmd/fuzz.go
+++ b/cmd/fuzz.go
@@ -304,10 +304,10 @@ func spawnApp(dev frida.DeviceInt, app string, p *tea.Program, toSpawn bool) {
 				break
 			}
 		}
-	}
 	sendStats(p, "Spawning app:"+app)
 	//Sleeping for a second before fuzzing so app spawn properly
 	time.Sleep(1 * time.Second)
+	}
 }
 
 func init() {


### PR DESCRIPTION
Adding support for app spawn. App will spawn only when not already in foreground.
i.e Not opened or app is in background.

This will help to wake up device (when unlocked) and start fuzzing. Instead of manually opening the app.
For continuous fuzzing, in case it crashes app and we want to keep it going, this will respawn app and keep looking for more crashes. (Will require more changes for continuous fuzzing, i plan on adding later)